### PR TITLE
Fixed the resource name regular expression

### DIFF
--- a/core/src/com/fteams/siftrain/assets/SimpleSongLoader.java
+++ b/core/src/com/fteams/siftrain/assets/SimpleSongLoader.java
@@ -47,7 +47,7 @@ public class SimpleSongLoader {
             song.setValid(false);
         } finally {
             if (song != null) {
-                song.setResourceName(handle.nameWithoutExtension().replaceAll("(_easy)|(_normal)|(_hard)|(_expert)", ""));
+                song.setResourceName(handle.nameWithoutExtension().replaceAll("(_easy)|(_normal)|(_hard)|(_expert)$", ""));
             }
         }
         return song;

--- a/core/src/com/fteams/siftrain/assets/SimplifiedBeatmapLoader.java
+++ b/core/src/com/fteams/siftrain/assets/SimplifiedBeatmapLoader.java
@@ -38,7 +38,7 @@ public class SimplifiedBeatmapLoader extends AsynchronousAssetLoader<BeatmapDesc
             beatmap.setFileName(fileName);
         }
         finally {
-            beatmap.setResourceName(handle.nameWithoutExtension().replaceAll("(_easy)|(_normal)|(_hard)|(_expert)", ""));
+            beatmap.setResourceName(handle.nameWithoutExtension().replaceAll("(_easy)|(_normal)|(_hard)|(_expert)$", ""));
         }
     }
 


### PR DESCRIPTION
The original regex would replace **all** instances of _easy, _normal, _hard, _expert within a given string, e.g. `very_easy_song_expert` becomes `very_song`. This fixed variant should only replace the one at the end of the string.

Please test it, though.
