### PR TITLE
Android 6.x permission fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: "android"
 
 android {
-    buildToolsVersion "22.0.1"
-    compileSdkVersion 22
+    buildToolsVersion "23.0.2"
+    compileSdkVersion 23
     lintOptions {
         abortOnError false
     }

--- a/android/src/com/fteams/siftrain/android/AndroidLauncher.java
+++ b/android/src/com/fteams/siftrain/android/AndroidLauncher.java
@@ -1,8 +1,11 @@
 package com.fteams.siftrain.android;
 
+import android.Manifest;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 
 import com.badlogic.gdx.backends.android.AndroidApplication;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
@@ -13,6 +16,16 @@ public class AndroidLauncher extends AndroidApplication {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (ContextCompat.checkSelfPermission(this.getContext(), Manifest.permission.READ_EXTERNAL_STORAGE)
+                == PackageManager.PERMISSION_DENIED) {
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, 1);
+        }
+        if (ContextCompat.checkSelfPermission(this.getContext(), Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                == PackageManager.PERMISSION_DENIED) {
+            ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE}, 2);
+        }
+
         AndroidApplicationConfiguration config = new AndroidApplicationConfiguration();
         try {
             PackageInfo pInfo = getPackageManager().getPackageInfo(getPackageName(), 0);

--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ project(":android") {
     dependencies {
         compile project(":core")
         compile "com.google.code.gson:gson:2.3.1"
+        compile "com.android.support:support-v4:23.1.1"
+        compile "com.android.support:appcompat-v7:23.1.1"
         compile "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
         natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi"
         natives "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-armeabi-v7a"


### PR DESCRIPTION
- Added permission check (and request) on startup
- updated Gradle scripts to Android API 23
- ContextCompat and ActivityCompact support libs used for backwards compatibility

It compiles and runs fine on my 5.1.1 phone. Haven't have time to set up a 6.x emulator yet so feel free to test it before merging (or wait for libgdx team to implement). 

You will probably need to update your Android SDK for it to compile.

More info: 
http://developer.android.com/training/permissions/requesting.html
http://developer.android.com/tools/support-library/index.html
